### PR TITLE
fix missing response.Body.Close()

### DIFF
--- a/pastebin.go
+++ b/pastebin.go
@@ -182,6 +182,7 @@ func (c *Client) doPastebinRequest(apiUrl string, fields url.Values, reAuthentic
 	if err != nil {
 		return nil, err
 	}
+	defer response.Body.Close()
 	if response.StatusCode != 200 {
 		return nil, errors.New(response.Status)
 	}
@@ -218,6 +219,7 @@ func GetPasteContent(pasteKey string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer response.Body.Close()
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return "", err
@@ -243,6 +245,7 @@ func GetPasteContentUsingScrapingAPI(pasteKey string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer response.Body.Close()
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return "", err
@@ -268,6 +271,7 @@ func GetPasteUsingScrapingAPI(pasteKey string) (*Paste, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer response.Body.Close()
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return nil, err
@@ -300,6 +304,7 @@ func GetRecentPastesUsingScrapingAPI(syntax string, limit int) ([]*Paste, error)
 	if err != nil {
 		return nil, err
 	}
+	defer response.Body.Close()
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
As mentioned in `Do` docs:

```go
// If the returned error is nil, the Response will contain a non-nil
// Body which the user is expected to close. If the Body is not both
// read to EOF and closed, the Client's underlying RoundTripper
// (typically Transport) may not be able to re-use a persistent TCP
// connection to the server for a subsequent "keep-alive" request.

```


I also thought of changing from your custom HttpClient interface to the default `http.RoundTripper` interface. What do you think?